### PR TITLE
Right align cohorts

### DIFF
--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -437,7 +437,8 @@ module Blazer
 
         @cohort_dates.each do |date|
           filtered_rows = @rows.select { |row| row[0] == date }
-          row = [date.strftime(date_format), filtered_rows[0][2] || 0] + (@cohort_dates.size - filtered_rows.size).times.map { 0 }
+          row = [date.strftime(date_format), filtered_rows[0][2] || 0]
+          row += (@cohort_dates.size - filtered_rows.size).times.map { 0 } if @statement.cohort_analysis_right_aligned?
 
           filtered_rows.size.times do |i|
             row << (filtered_rows[i] ? filtered_rows[i][2] : 0)

--- a/app/controllers/blazer/queries_controller.rb
+++ b/app/controllers/blazer/queries_controller.rb
@@ -425,16 +425,21 @@ module Blazer
       else
         @today = Blazer.time_zone.today
         @cohort_dates = @rows.map { |row| row[0] }.uniq.sort
-        num_cols = @cohort_dates.size
-        @columns = ["Cohort", "Users"] + num_cols.times.map { |i| "#{@conversion_period.titleize} #{i + 1}" }
-        rows = []
+        @cohort_period_cols = @cohort_dates.size
         date_format = @cohort_period == "month" ? "%b %Y" : "%b %-e, %Y"
-        
+        rows = []
+
+        if @statement.cohort_analysis_right_aligned?
+          @columns = @cohort_dates.map { |date| date.strftime(date_format) }
+        else
+          @columns = @cohort_period_cols.times.map { |i| "#{@conversion_period.titleize} #{i + 1}" }
+        end
+
         @cohort_dates.each do |date|
           filtered_rows = @rows.select { |row| row[0] == date }
-          row = [date.strftime(date_format), filtered_rows[0][2] || 0]
+          row = [date.strftime(date_format), filtered_rows[0][2] || 0] + (@cohort_dates.size - filtered_rows.size).times.map { 0 }
 
-          num_cols.times do |i|
+          filtered_rows.size.times do |i|
             row << (filtered_rows[i] ? filtered_rows[i][2] : 0)
           end
 

--- a/app/views/blazer/queries/_cohorts.html.erb
+++ b/app/views/blazer/queries/_cohorts.html.erb
@@ -5,14 +5,13 @@
   </p>
 <% end %>
 <% if @rows.any? %>
-  <% cohort_period_cols = @rows.map(&:length).max - 2 %>
   <div class="results-container">
     <table class="table results-table">
       <thead>
         <tr>
           <th style="min-width: 100px;">Cohort</th>
-          <% cohort_period_cols.times do |i| %>
-            <th style="width: 7.5%; text-align: right;"><%= @conversion_period.titleize %> <%= i + 1 %></th>
+          <% @columns.each do |column| %>
+            <th style="width: 10%; text-align: right;"><%= column %></th>
           <% end %>
         </tr>
       </thead>
@@ -23,7 +22,7 @@
               <%= row[0] %>
               <div style="font-size: 12px; color: #999;"><%= row[1] == 1 ? "1 user" : "#{number_with_delimiter(row[1])} users" %></div>
             </td>
-            <% cohort_period_cols.times do |i| %>
+            <% @cohort_period_cols.times do |i| %>
               <td style="text-align: right;">
                 <% num = row[i + 2] %>
                 <% if num && !num.zero? %>

--- a/app/views/blazer/queries/_cohorts.html.erb
+++ b/app/views/blazer/queries/_cohorts.html.erb
@@ -17,22 +17,26 @@
       </thead>
       <tbody>
         <% @rows.each do |row| %>
+          <% denom = row[1] %>
           <tr>
             <td>
               <%= row[0] %>
-              <div style="font-size: 12px; color: #999;"><%= row[1] == 1 ? "1 user" : "#{number_with_delimiter(row[1])} users" %></div>
+              <div style="font-size: 12px; color: #999;"><%= denom == 1 ? "1 user" : "#{number_with_delimiter(denom)} users" %></div>
             </td>
             <% @cohort_period_cols.times do |i| %>
               <td style="text-align: right;">
                 <% num = row[i + 2] %>
                 <% if num && !num.zero? %>
-                  <% denom = row[1] %>
-                  <% if denom > 0 %>
-                    <%= (100.0 * num / denom).round %>%
+                  <% if @statement.cohort_analysis_right_aligned? %>
+                    <% primary = number_with_delimiter(num) %>
+                    <% secondary = denom > 0 ? "#{(100.0 * num / denom).round}%" : "-" %>
                   <% else %>
-                    -
+                    <% primary = denom > 0 ? "#{(100.0 * num / denom).round}%" : "-" %>
+                    <% secondary = number_with_delimiter(num) %>
                   <% end %>
-                  <div style="font-size: 12px; color: #999;"><%= number_with_delimiter(num) %></div>
+                  
+                  <%= primary %>
+                  <div style="font-size: 12px; color: #999;"><%= secondary %></div>
                 <% else %>
                   -
                 <% end %>

--- a/lib/blazer/adapters/sql_adapter.rb
+++ b/lib/blazer/adapters/sql_adapter.rb
@@ -145,7 +145,7 @@ module Blazer
         tzname = Blazer.time_zone.tzinfo.name
 
         if mysql?
-          time_sql = "CONVERT_TZ(cohorts.cohort_time, '+00:00', ?)"
+          time_sql = "CONVERT_TZ(#{cohort_column}, '+00:00', ?)"
           case period
           when "day"
             date_sql = "CAST(DATE_FORMAT(#{time_sql}, '%Y-%m-%d') AS DATE)"
@@ -160,53 +160,24 @@ module Blazer
             date_sql = "CAST(DATE_FORMAT(#{time_sql}, '%Y-%m-01') AS DATE)"
             date_params = [tzname]
           end
-          bucket_sql = "CAST(CEIL(TIMESTAMPDIFF(SECOND, cohorts.cohort_time, query.conversion_time) / ?) AS SIGNED)"
         else
-          date_sql = "date_trunc(?, cohorts.cohort_time::timestamptz AT TIME ZONE ?)::date"
+          date_sql = "DATE_TRUNC(?, #{cohort_column}::timestamptz AT TIME ZONE ?)::date"
           date_params = [period, tzname]
-          bucket_sql = "CEIL(EXTRACT(EPOCH FROM query.conversion_time - cohorts.cohort_time) / ?)::int"
         end
-
-        # WITH not an optimization fence in Postgres 12+
-        # statement = <<~SQL
-        #   WITH query AS (
-        #     {placeholder}
-        #   ),
-        #   cohorts AS (
-        #     SELECT user_id, MIN(#{cohort_column}) AS cohort_time FROM query
-        #     WHERE user_id IS NOT NULL AND #{cohort_column} IS NOT NULL
-        #     GROUP BY 1
-        #   )
-        #   SELECT
-        #     #{date_sql} AS period,
-        #     0 AS bucket,
-        #     COUNT(DISTINCT cohorts.user_id)
-        #   FROM cohorts GROUP BY 1
-        #   UNION ALL
-        #   SELECT
-        #     #{date_sql} AS period,
-        #     #{bucket_sql} AS bucket,
-        #     COUNT(DISTINCT query.user_id)
-        #   FROM cohorts INNER JOIN query ON query.user_id = cohorts.user_id
-        #   WHERE query.conversion_time IS NOT NULL
-        #   AND query.conversion_time >= cohorts.cohort_time
-        #   #{cohort_column == "conversion_time" ? "AND query.conversion_time != cohorts.cohort_time" : ""}
-        #   GROUP BY 1, 2
-        # SQL
 
         statement = <<~SQL
           WITH query AS (
             {placeholder}
           ),
           min_user_date AS (
-            SELECT user_id, DATE_TRUNC('month', MIN(#{cohort_column})) AS cohort_date 
+            SELECT user_id, MIN(#{date_sql}) AS cohort_date 
             FROM query
             WHERE user_id IS NOT NULL 
               AND #{cohort_column} IS NOT NULL
             GROUP BY 1
           ),
           user_detail AS (
-            SELECT DATE_TRUNC('month', #{cohort_column}) AS conversion_date,
+            SELECT #{date_sql} AS conversion_date,
               user_id
             FROM query
             ORDER BY 2, 1
@@ -219,7 +190,7 @@ module Blazer
           GROUP BY 1, 2
           ORDER BY 1, 2
         SQL
-        params = [statement] + date_params + date_params + [days.to_i * 86400]
+        params = [statement] + date_params + date_params
         connection_model.send(:sanitize_sql_array, params)
       end
 

--- a/lib/blazer/statement.rb
+++ b/lib/blazer/statement.rb
@@ -46,7 +46,15 @@ module Blazer
     end
 
     def cohort_analysis?
-      /\/\*\s*cohort analysis\s*\*\//i.match?(statement)
+      cohort_analysis_left_aligned? || cohort_analysis_right_aligned?
+    end
+
+    def cohort_analysis_left_aligned?
+      @cohort_analysis_left_aligned ||= /\/\*\s*cohort analysis\s*\*\//i.match?(statement)
+    end
+
+    def cohort_analysis_right_aligned?
+      @cohort_analysis_right_aligned ||= /\/\*\s*cohort analysis right align\s*\*\//i.match?(statement)
     end
 
     def apply_cohort_analysis(period:, days:)


### PR DESCRIPTION
To right align a cohort, use the comment `/* cohort analysis right align */` in the SQL statement.

When you right align a cohort:
- The dates appear as column names (instead of Week 1, Week 2, ...)
- The triangle is right aligned instead of left aligned (values push to the right)
- Values are displayed and percentages are secondary (instead of the opposite)
